### PR TITLE
掲示板一覧機能の実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,9 @@ gem 'sorcery'
 #internationalization
 gem 'rails-i18n', '~> 7.0.0' 
 
+#testdata
+gem 'faker'
+
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,6 +104,8 @@ GEM
       reline (>= 0.3.8)
     drb (2.2.1)
     erubi (1.12.0)
+    faker (3.4.1)
+      i18n (>= 1.8.11, < 2)
     faraday (2.9.0)
       faraday-net_http (>= 2.0, < 3.2)
     faraday-net_http (3.1.0)
@@ -293,6 +295,7 @@ DEPENDENCIES
   capybara
   cssbundling-rails
   debug
+  faker
   jbuilder
   jsbundling-rails
   pg (~> 1.1)

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,0 +1,5 @@
+class PostsController < ApplicationController
+    def index
+        @posts = Post.includes(:user)
+    end
+end

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -5,7 +5,7 @@ class UserSessionsController < ApplicationController
   def create
     @user = login(params[:email],params[:password])
     if @user
-      redirect_to root_path, success: 'ログインに成功しました'
+      redirect_to posts_path, success: 'ログインに成功しました'
     else
       flash.now[:alert] = 'ログインに失敗しました'
       render :new, status: :unprocessable_entity

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -8,7 +8,7 @@ class UsersController < ApplicationController
     @user = User.new(user_params)
     if @user.save
       login(user_params[:email], user_params[:password])
-      redirect_to root_path, success: 'ログインしました'
+      redirect_to posts_path, success: 'ユーザー登録に成功しました'
     else
       flash.now[:alert] = 'ユーザー登録に失敗しました'
       render :new, status: :unprocessable_entity

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,0 +1,8 @@
+class Post < ApplicationRecord
+    validates :title, presence: true, length: { maximum: 255 }
+    validates :body, presence: true, length: { maximum: 65_535 }
+    enum drink_type: { hot: 0, cold: 1 }
+    enum drink_time: { morning: 0, midmorning: 1, noon: 2, afternoon: 3,  evening:4, midnight:5 }
+
+    belongs_to :user
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,4 +7,5 @@ class User < ApplicationRecord
 
   validates :email, uniqueness: true, presence: true # emailを入力必須に
   validates :name, presence: true, length: {maximum: 255} #name要素を入力必須、255文字まで。
+  has_many :posts, dependent: :destroy
 end

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -1,0 +1,15 @@
+<div class="p-4 md:w-1/3">
+    <div class="card w-auto bg-base-100 shadow-xl sm:w-full">
+        <figure><img src="https://img.daisyui.com/images/stock/photo-1606107557195-0e29a4b5b4aa.jpg" alt="Shoes" /></figure>
+            <div class="card-body">
+                <h2 class="card-title">
+                    <%= post.title %>
+                </h2>
+                <p><%= post.body %></p>
+                <div class="card-actions justify-end">
+                <div class="badge badge-outline"><%= post.drink_type %></div> 
+                <div class="badge badge-outline"><%= post.drink_time %></div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,0 +1,11 @@
+<section class="text-gray-600 body-font">
+  <div class="container px-5 py-24 mx-auto">
+    <div class="flex flex-wrap -m-4">
+        <% if @posts.present? %>
+            <%= render @posts %>
+        <% else %>
+            <div class="text-base m-auto">投稿がありません</div>
+        <% end %>
+    </div>
+  </div>
+</section>

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -8,7 +8,7 @@
         <div class="flex-none">
             <ul class="menu menu-horizontal px-1 text-xs md:text-base ml-auto">
                 <li>
-                     <%= link_to 'Timeline', '#'  %>
+                     <%= link_to 'Timeline', posts_path  %>
                 </li>
                 <li>
                     <details>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -8,7 +8,7 @@
         <div class="flex-none">
             <ul class="menu menu-horizontal px-1 text-xs md:text-base ml-auto">
                 <li>
-                     <%= link_to 'Timeline', '#'  %>
+                     <%= link_to 'Timeline', posts_path  %>
                 </li>
                 <li>
                     <details>

--- a/config/application.rb
+++ b/config/application.rb
@@ -28,5 +28,6 @@ module Myapp
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
     config.i18n.default_locale = :ja
+    config.time_zone = 'Tokyo'
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
   root 'staticpages#top'
 
   resources :users, only: %i[new create]
-
+  resources :posts, only: %i[index]
   get 'login', to: 'user_sessions#new'
   post 'login', to: 'user_sessions#create'
   delete 'logout', to: 'user_sessions#destroy'

--- a/db/migrate/20240606055111_create_posts.rb
+++ b/db/migrate/20240606055111_create_posts.rb
@@ -1,0 +1,12 @@
+class CreatePosts < ActiveRecord::Migration[7.1]
+  def change
+    create_table :posts do |t|
+      t.string :title, null: false
+      t.text :body, null: false
+      t.integer :drink_type,  null: false, default: 0
+      t.integer :drink_time,  null: false, default: 0
+      t.references :user, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,17 +10,30 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_03_222432) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_06_055111) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "posts", force: :cascade do |t|
+    t.string "title", null: false
+    t.text "body", null: false
+    t.integer "drink_type", default: 0, null: false
+    t.integer "drink_time", default: 0, null: false
+    t.bigint "user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_posts_on_user_id"
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "email", null: false
     t.string "crypted_password"
     t.string "salt"
+    t.string "name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 
+  add_foreign_key "posts", "users"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,3 +7,19 @@
 #   ["Action", "Comedy", "Drama", "Horror"].each do |genre_name|
 #     MovieGenre.find_or_create_by!(name: genre_name)
 #   end
+p '==================== user post data create ===================='
+10.times do |n|
+    User.create!(
+        name: Faker::Name.unique.last_name,
+        email: Faker::Internet.unique.email,
+        password: 'password',
+        password_confirmation: 'password'
+    )
+end
+
+user_ids = User.ids
+
+20.times do |index|
+  user = User.find(user_ids.sample)
+  user.posts.create!(title: "タイトル#{index}", body: "本文#{index}", drink_type: (0..1).to_a.sample, drink_time: (0..5).to_a.sample)
+end


### PR DESCRIPTION
## 掲示板一覧機能の実装
### 概要
- 掲示板のためのPostモデルの作成
- 掲示板一覧表示のための機能実装
- `gem faker`を導入し、一覧画面の実装を確認
- 既存の機能の修正
### 詳細

- [X] Postモデルを追加。Userモデルとのリレーション、バリデーション、`drink_type`と`drink_time`についてはenumを指定
- [X] posts_controllerの実装
- [X] app/views/posts配下にindex.html.erb及び_post.html.erbを作成し一覧画面の表示
- [X] `gem faker`を導入し、seedファイルでuserとpostのデータを作成し、表示を確認済み。
- [X] config/application.rbでtimezoneを日本に設定
- [X] ヘッダーの「Timeline」から投稿一覧画面へリンクできるように指定
- [X] ログイン及び新規登録した際の遷移先を投稿一覧画面へ変更