### PR TITLE
投稿詳細画面の実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,9 +57,16 @@ gem 'faker'
 gem 'carrierwave', '~> 3.0'
 gem "mini_magick"
 gem 'fog-aws'
+gem "aws-sdk-s3", require: false 
 
 #environment variables
 gem 'dotenv-rails'
+
+#decorator
+gem 'draper'
+
+#pagination
+gem 'kaminari'
 
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,6 +55,10 @@ GEM
       globalid (>= 0.3.6)
     activemodel (7.1.3.3)
       activesupport (= 7.1.3.3)
+    activemodel-serializers-xml (1.0.2)
+      activemodel (> 5.x)
+      activesupport (> 5.x)
+      builder (~> 3.1)
     activerecord (7.1.3.3)
       activemodel (= 7.1.3.3)
       activesupport (= 7.1.3.3)
@@ -77,6 +81,22 @@ GEM
       tzinfo (~> 2.0)
     addressable (2.8.6)
       public_suffix (>= 2.0.2, < 6.0)
+    aws-eventstream (1.3.0)
+    aws-partitions (1.941.0)
+    aws-sdk-core (3.197.0)
+      aws-eventstream (~> 1, >= 1.3.0)
+      aws-partitions (~> 1, >= 1.651.0)
+      aws-sigv4 (~> 1.8)
+      jmespath (~> 1, >= 1.6.1)
+    aws-sdk-kms (1.83.0)
+      aws-sdk-core (~> 3, >= 3.197.0)
+      aws-sigv4 (~> 1.1)
+    aws-sdk-s3 (1.152.0)
+      aws-sdk-core (~> 3, >= 3.197.0)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.8)
+    aws-sigv4 (1.8.0)
+      aws-eventstream (~> 1, >= 1.0.2)
     base64 (0.2.0)
     bcrypt (3.1.20)
     bigdecimal (3.1.8)
@@ -113,6 +133,13 @@ GEM
     dotenv-rails (3.1.2)
       dotenv (= 3.1.2)
       railties (>= 6.1)
+    draper (4.0.2)
+      actionpack (>= 5.0)
+      activemodel (>= 5.0)
+      activemodel-serializers-xml (>= 1.0)
+      activesupport (>= 5.0)
+      request_store (>= 1.0)
+      ruby2_keywords
     drb (2.2.1)
     erubi (1.12.0)
     excon (0.110.0)
@@ -159,10 +186,23 @@ GEM
     jbuilder (2.12.0)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
+    jmespath (1.6.2)
     jsbundling-rails (1.3.0)
       railties (>= 6.0.0)
     jwt (2.8.1)
       base64
+    kaminari (1.2.2)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.2)
+      kaminari-activerecord (= 1.2.2)
+      kaminari-core (= 1.2.2)
+    kaminari-actionview (1.2.2)
+      actionview
+      kaminari-core (= 1.2.2)
+    kaminari-activerecord (1.2.2)
+      activerecord
+      kaminari-core (= 1.2.2)
+    kaminari-core (1.2.2)
     loofah (2.22.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -274,10 +314,13 @@ GEM
     regexp_parser (2.9.2)
     reline (0.5.8)
       io-console (~> 0.5)
+    request_store (1.7.0)
+      rack (>= 1.4)
     rexml (3.2.8)
       strscan (>= 3.0.9)
     ruby-vips (2.2.1)
       ffi (~> 1.12)
+    ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
     selenium-webdriver (4.21.1)
       base64 (~> 0.2)
@@ -336,16 +379,19 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  aws-sdk-s3
   bootsnap
   capybara
   carrierwave (~> 3.0)
   cssbundling-rails
   debug
   dotenv-rails
+  draper
   faker
   fog-aws
   jbuilder
   jsbundling-rails
+  kaminari
   mini_magick
   pg (~> 1.1)
   puma (>= 5.0)

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,6 +1,6 @@
 class PostsController < ApplicationController
     def index
-        @posts = Post.includes(:user).order(created_at: :desc)
+        @posts = Post.includes(:user).order(created_at: :desc).page params[:page]
     end
 
     def new
@@ -15,10 +15,20 @@ class PostsController < ApplicationController
             flash.now[:danger] = "投稿に失敗しました"
             render :new, status: :unprocessable_entity
         end
+    end
 
+    def show
+        @post = Post.find(params[:id])
+    end
+
+    def destroy
+        post = current_user.posts.find(params[:id])
+        post.destroy!
+        redirect_to posts_path, success: "投稿を削除しました"
     end
 
     def post_params
         params.require(:post).permit(:title, :body, :drink_time, :drink_type, :post_image, :post_image_cache )
     end
+
 end

--- a/app/decorators/post_decorator.rb
+++ b/app/decorators/post_decorator.rb
@@ -1,0 +1,60 @@
+class PostDecorator < Draper::Decorator
+  delegate_all
+
+  def drink_type_show
+    if object.drink_type == "cold"
+      h.content_tag(:div, class: 'flex items-center') do
+        h.concat(h.content_tag(:span, 'ac_unit', class: 'material-icons'))
+        h.concat(h.content_tag(:span, 'cold', class: 'ml-2'))
+      end
+    else 
+      h.content_tag(:div, class: 'flex items-center') do
+        h.concat(h.content_tag(:span, 'coffee', class: 'material-icons'))
+        h.concat(h.content_tag(:span, 'hot', class: 'ml-2'))
+      end
+    end
+  end
+
+  def drink_time_show
+    if object.drink_time == "morning"
+      h.content_tag(:div, class: 'flex items-center') do
+        h.concat(h.content_tag(:span, 'wb_twilight', class: 'material-icons'))
+        h.concat(h.content_tag(:span, 'morning', class: 'ml-2'))
+      end
+    elsif object.drink_time == "midmorning"
+      h.content_tag(:div, class: 'flex items-center') do
+        h.concat(h.content_tag(:span, 'wb_twilight', class: 'material-icons'))
+        h.concat(h.content_tag(:span, 'midmorning', class: 'ml-2'))
+      end
+    elsif object.drink_time == "noon"
+      h.content_tag(:div, class: 'flex items-center') do
+        h.concat(h.content_tag(:span, 'wb_sunny', class: 'material-icons'))
+        h.concat(h.content_tag(:span, 'noon', class: 'ml-2'))
+      end
+    elsif object.drink_time == "afternoon"
+      h.content_tag(:div, class: 'flex items-center') do
+        h.concat(h.content_tag(:span, 'wb_sunny', class: 'material-icons'))
+        h.concat(h.content_tag(:span, 'afternoon', class: 'ml-2'))
+      end
+    elsif object.drink_time == "evening"
+      h.content_tag(:div, class: 'flex items-center') do
+        h.concat(h.content_tag(:span, 'nights_stay', class: 'material-icons'))
+        h.concat(h.content_tag(:span, 'evening', class: 'ml-2'))
+      end
+    else
+      h.content_tag(:div, class: 'flex items-center') do
+        h.concat(h.content_tag(:span, 'nights_stay', class: 'material-icons'))
+        h.concat(h.content_tag(:span, 'night', class: 'ml-2'))
+      end
+    end
+  end
+  # Define presentation-specific methods here. Helpers are accessed through
+  # `helpers` (aka `h`). You can override attributes, for example:
+  #
+  #   def created_at
+  #     helpers.content_tag :span, class: 'time' do
+  #       object.created_at.strftime("%a %m/%d/%y")
+  #     end
+  #   end
+
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,4 +8,8 @@ class User < ApplicationRecord
   validates :email, uniqueness: true, presence: true # emailを入力必須に
   validates :name, presence: true, length: {maximum: 255} #name要素を入力必須、255文字まで。
   has_many :posts, dependent: :destroy
+
+  def own?(object)
+    object.user_id == id
+  end
 end

--- a/app/uploaders/post_image_uploader.rb
+++ b/app/uploaders/post_image_uploader.rb
@@ -28,7 +28,7 @@ class PostImageUploader < CarrierWave::Uploader::Base
    end
 
   # Process files as they are uploaded:
-   process resize_to_fit: [300, 200]
+   process resize_to_fit: [400, 400]
   #
   # def scale(width, height)
   #   # do something

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -1,17 +1,20 @@
 <div class="p-4 md:w-1/3">
+    <%= link_to post_path(post) do %>
     <div class="card w-auto bg-base-100 shadow-xl sm:w-full">
-        <figure>
-            <%= image_tag post.post_image_url, size: '300x200' %>
+        <figure class = "mx-auto">
+            <%= image_tag post.post_image_url, class: 'object-contain w-72 h-72' %>
         </figure>
             <div class="card-body">
+                <%= post.user.name %>
                 <h2 class="card-title">
-                    <%= post.title %>
+                    <%= post.title.truncate(17) %>
                 </h2>
-                <p><%= post.body %></p>
+                <p><%= post.body.truncate(22) %></p>
                 <div class="card-actions justify-end">
                 <div class="badge badge-outline"><%= post.drink_type %></div> 
                 <div class="badge badge-outline"><%= post.drink_time %></div>
             </div>
         </div>
     </div>
+    <% end %>
 </div>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -10,5 +10,8 @@
                 <div class="text-base m-auto">投稿がありません</div>
             <% end %>
         </div>
+        <div class= 'mt-6 text-center text-lg'>
+        <%= paginate @posts %>
+        </div>
     </div>
 </section>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -30,13 +30,13 @@
 
           <%= f.label :drink_type, class: "label w-full md:w-1/2 mx-auto" %>
             <div class="mx-auto w-full md:w-1/2 text-center">
-            <div class="vertical-align">
+             <div class="vertical-align">
                 <%= f.radio_button :drink_type,:hot,  class: "radio radio-secondary ml-6"%>
                 <span class="material-icons">coffee</span>
                 <%= f.radio_button :drink_type,:cold, class: "radio radio-primary ml-6" %>
                 <span class="material-icons">ac_unit</span>
              </div>
-          </div>
+            </div>
           
           <%= f.label :post_image, class: "label w-full md:w-1/2 mx-auto" %>
           <%= f.file_field :post_image, class:"file-input file-input-bordered file-input-accent form-control w-full md:w-1/2 mx-auto" %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,0 +1,23 @@
+<div class='container'>
+    <div class= 'md:w-1/2 mx-auto'>
+        <div class='text-center mt-6'><%= @post.user.name %></div>
+        <div class='text-center mt-6'>
+            <h1 class = "text-2xl font-semibold mb-6"><%= @post.title %></h1>
+        </div>
+        <%= image_tag @post.post_image_url,  class: 'object-contain w-72 h-72 mx-auto mb-6' %>
+    <p class= 'mb-6 w-full mx-auto bg-base-200 p-10 rounded-lg'><%= @post.body%></p>
+            <div class='flex flex-center mb-6'>
+                <div class = "mr-6"><%= @post.decorate.drink_type_show %></div>
+                <div class><%= @post.decorate.drink_time_show %></div>
+            </div>
+    <div class='text-center mb-6'>
+        <% if current_user.own?(@post)%>
+            <%= link_to '編集', "#", class: "btn btn-primary"  %>
+            <%= link_to '削除', post_path(@post), data: {turbo_method: :delete, turbo_confirm: "投稿を削除しますか？"}, class: "btn btn-secondary" %>
+        <% end %>
+    </div>
+    <div class='text-center mb-6'>
+        <%= link_to "投稿一覧ページへ", posts_path %>
+    </div>
+    </div>
+</div>

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+Kaminari.configure do |config|
+   config.default_per_page = 18
+  # config.max_per_page = nil
+  # config.window = 4
+  # config.outer_window = 0
+  # config.left = 0
+  # config.right = 0
+  # config.page_method_name = :page
+  # config.param_name = :page
+  # config.max_pages = nil
+  # config.params_on_first_page = false
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
   root 'staticpages#top'
 
   resources :users, only: %i[new create]
-  resources :posts, only: %i[index new create]
+  resources :posts, only: %i[index new create show destroy] 
   get 'login', to: 'user_sessions#new'
   post 'login', to: 'user_sessions#create'
   delete 'logout', to: 'user_sessions#destroy'


### PR DESCRIPTION
## 概要
投稿詳細画面の実装
一覧画面の調整
削除機能の実装
## 詳細
#### 投稿詳細画面の実装

- [X] app/controllers/posts_controller.rbにshowアクションの追加
- [X] config/routes.rbにshowを追加
- [X] app/views/posts/show.html.erbで詳細画面の実装
- [X] `gem 'draper'`を追加。デコレータを用いて詳細画面の表示分け

#### 一覧画面の調整
- [X] app/views/posts/_post.html.erbで投稿一覧画面の画像表示サイズの調整
- [X]  app/uploaders/post_image_uploader.rbで画像のアップロードサイズの変更。
- [X] `gem 'kaminari'`の追加。ページネーションの実装。

#### 投稿削除機能
- [X] app/controllers/posts_controller.rbにdestroyアクションの追加
- [X] config/routes.rbにdestroyを追加
- [X] app/views/posts/show.html.erbで本人の投稿のみ編集・削除ボタンが表示されるようにした