### PR TITLE
スマホでトップページからだとヘッダーのトグルボタンが押せない問題解決

### DIFF
--- a/app/views/staticpages/top.html.erb
+++ b/app/views/staticpages/top.html.erb
@@ -1,6 +1,6 @@
-<div class="hero min-h-screen bg-base-100">
+<div class="hero min-h-screen bg-base-100 mt-16 md:mt-0">
   <div class="hero-content flex-col lg:flex-row-reverse">
-    <%= image_tag "top.png", class: "mt-6"%>
+    <%= image_tag "top.png"%>
     <div>
       <h1 class="text-5xl font-bold"><%= 'My Coffee Diary' %></h1>
       <p class="py-6"><%= '毎日の生活を彩る漆黒の液体、コーヒー' %></p>


### PR DESCRIPTION
## 概要
- スマホでトップページからだとヘッダーのトグルボタンが押せない問題解決
## 詳細

- [X] app/views/staticpages/top.html.erbに`mt-16 md:mt-0`を追加 